### PR TITLE
Handle non-numeric sleep study columns before aggregation

### DIFF
--- a/study.py
+++ b/study.py
@@ -35,6 +35,10 @@ if rename_map:
 needed = ["record_id", "redcap_event", "Efficiency_Mean", "koos_pain"]
 df = df_raw.loc[:, needed].copy()
 
+# ensure numeric columns are parsed as numbers
+for col in ["Efficiency_Mean", "koos_pain"]:
+    df[col] = pd.to_numeric(df[col], errors="coerce")
+
 # 5. de-duplicate accidental repeats by averaging numeric values
 df = (df
       .groupby(["record_id", "redcap_event"], as_index=False)


### PR DESCRIPTION
## Summary
- Coerce `Efficiency_Mean` and `koos_pain` fields to numeric so aggregation works as intended

## Testing
- `python -m py_compile study.py`
- `python study.py` *(fails: AttributeError: module 'importlib' has no attribute 'util')*


------
https://chatgpt.com/codex/tasks/task_e_6894b7b6a5048331bf76cf2500f54a61